### PR TITLE
feat: add FastAPI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ Desktop.ini
 # Windows Zone.Identifier alternate stream copies
 *:Zone.Identifier
 
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.python-version
+.pytest_cache/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+sqlalchemy
+psycopg2-binary
+pydantic
+pyyaml
+pytest

--- a/tests/test_checkins.py
+++ b/tests/test_checkins.py
@@ -1,0 +1,40 @@
+import os
+
+os.environ['DATABASE_URL'] = 'sqlite+pysqlite:///:memory:'
+
+from fastapi.testclient import TestClient
+
+from trailguard_api.main import app
+from trailguard_api import models
+from trailguard_api.database import Base, engine, SessionLocal
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+
+def create_user(user_id: str):
+    db = SessionLocal()
+    db.add(models.User(id=user_id))
+    db.commit()
+    db.close()
+
+
+def test_create_and_list_checkins():
+    user_id = 'user1'
+    create_user(user_id)
+    payload = {
+        'checkIn': {
+            'type': 'ok',
+            'message': 'hello',
+            'location': {'lat': 1.0, 'lng': 2.0}
+        }
+    }
+    resp = client.post(f'/v1/users/{user_id}/checkIns', json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data['type'] == 'ok'
+
+    resp = client.get(f'/v1/users/{user_id}/checkIns')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data['checkIns']) == 1

--- a/trailguard_api/database.py
+++ b/trailguard_api/database.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql+psycopg2://postgres:postgres@localhost/trailguard')
+
+engine = create_engine(DATABASE_URL, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def init_db():
+    """Run the SQL migration if using PostgreSQL."""
+    if engine.url.get_backend_name().startswith('postgresql'):
+        sql_path = Path('migrations/001_init.sql')
+        if sql_path.exists():
+            sql = sql_path.read_text()
+            with engine.begin() as conn:
+                conn.exec_driver_sql(sql)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/trailguard_api/main.py
+++ b/trailguard_api/main.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import yaml
+from fastapi import FastAPI
+
+from .database import init_db
+from .routers import checkins
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+
+    schema_path = Path('openapi.yaml')
+    if schema_path.exists():
+        with schema_path.open() as f:
+            openapi_schema = yaml.safe_load(f)
+
+        def custom_openapi():
+            return openapi_schema
+
+        app.openapi = custom_openapi
+
+    app.include_router(checkins.router)
+
+    @app.on_event('startup')
+    def on_startup():
+        init_db()
+
+    return app
+
+
+app = create_app()

--- a/trailguard_api/models.py
+++ b/trailguard_api/models.py
@@ -1,0 +1,128 @@
+import uuid
+from datetime import datetime
+from sqlalchemy import Column, String, Integer, Boolean, ForeignKey, DateTime, Float, Text
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+def uuid4_str() -> str:
+    return str(uuid.uuid4())
+
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(String, primary_key=True, default=uuid4_str)
+    email = Column(Text, unique=True)
+    display_name = Column(Text)
+    create_time = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+    devices = relationship('Device', back_populates='user')
+
+
+class Device(Base):
+    __tablename__ = 'devices'
+
+    id = Column(String, primary_key=True, default=uuid4_str)
+    user_id = Column(String, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
+    name = Column(Text)
+    battery_percent = Column(Integer)
+    solar = Column(Boolean, nullable=False, default=False)
+    connection_state = Column(Text, default='OFFLINE')
+    firmware_version = Column(Text)
+    last_seen_time = Column(DateTime(timezone=True))
+    lat = Column(Float)
+    lng = Column(Float)
+    accuracy_meters = Column(Float)
+    pairing_code = Column(Text, unique=True)
+    paired_at = Column(DateTime(timezone=True))
+    create_time = Column(DateTime(timezone=True), default=datetime.utcnow)
+    update_time = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+    user = relationship('User', back_populates='devices')
+    breadcrumbs = relationship('Breadcrumb', back_populates='device')
+    check_ins = relationship('CheckIn', back_populates='device')
+    messages = relationship('Message', back_populates='device')
+
+
+class Breadcrumb(Base):
+    __tablename__ = 'breadcrumbs'
+
+    id = Column(String, primary_key=True, default=uuid4_str)
+    device_id = Column(String, ForeignKey('devices.id', ondelete='CASCADE'), nullable=False)
+    recorded_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    lat = Column(Float, nullable=False)
+    lng = Column(Float, nullable=False)
+    accuracy_meters = Column(Float)
+    create_time = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+    device = relationship('Device', back_populates='breadcrumbs')
+
+
+class CheckIn(Base):
+    __tablename__ = 'check_ins'
+
+    id = Column(String, primary_key=True, default=uuid4_str)
+    user_id = Column(String, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
+    device_id = Column(String, ForeignKey('devices.id', ondelete='SET NULL'))
+    type = Column(Text, nullable=False)
+    message = Column(Text)
+    lat = Column(Float)
+    lng = Column(Float)
+    accuracy_meters = Column(Float)
+    create_time = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+    user = relationship('User')
+    device = relationship('Device', back_populates='check_ins')
+
+
+class SOSSession(Base):
+    __tablename__ = 'sos_sessions'
+
+    id = Column(String, primary_key=True, default=uuid4_str)
+    user_id = Column(String, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
+    message = Column(Text)
+    start_time = Column(DateTime(timezone=True), default=datetime.utcnow)
+    cancel_time = Column(DateTime(timezone=True))
+    last_lat = Column(Float)
+    last_lng = Column(Float)
+    last_accuracy_meters = Column(Float)
+    create_time = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+
+class FamilyMember(Base):
+    __tablename__ = 'family_members'
+
+    id = Column(String, primary_key=True, default=uuid4_str)
+    user_id = Column(String, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
+    display_name = Column(Text, nullable=False)
+    status = Column(Text)
+    last_seen_time = Column(DateTime(timezone=True))
+    create_time = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+
+class UserSetting(Base):
+    __tablename__ = 'user_settings'
+
+    user_id = Column(String, ForeignKey('users.id', ondelete='CASCADE'), primary_key=True)
+    auto_alerts = Column(Boolean, nullable=False, default=False)
+    notify_contacts = Column(Boolean, nullable=False, default=False)
+    sos_auto_call = Column(Boolean, nullable=False, default=False)
+    geofence_radius_meters = Column(Integer, nullable=False, default=0)
+    update_time = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+
+class Message(Base):
+    __tablename__ = 'messages'
+
+    id = Column(String, primary_key=True, default=uuid4_str)
+    user_id = Column(String, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
+    device_id = Column(String, ForeignKey('devices.id', ondelete='SET NULL'))
+    text = Column(Text, nullable=False)
+    lat = Column(Float)
+    lng = Column(Float)
+    accuracy_meters = Column(Float)
+    create_time = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+    device = relationship('Device', back_populates='messages')

--- a/trailguard_api/routers/checkins.py
+++ b/trailguard_api/routers/checkins.py
@@ -1,0 +1,55 @@
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..database import get_db
+
+router = APIRouter(prefix='/v1/users/{user_id}/checkIns', tags=['CheckIns'])
+
+
+def to_checkin_response(ci: models.CheckIn) -> schemas.CheckInResponse:
+    location = None
+    if ci.lat is not None and ci.lng is not None:
+        location = schemas.Location(lat=ci.lat, lng=ci.lng, accuracy_meters=ci.accuracy_meters)
+    return schemas.CheckInResponse(
+        name=f'users/{ci.user_id}/checkIns/{ci.id}',
+        type=ci.type,
+        message=ci.message,
+        device_id=ci.device_id,
+        location=location,
+        create_time=ci.create_time,
+    )
+
+
+@router.get('', response_model=schemas.CheckInListResponse)
+def list_checkins(
+    user_id: str,
+    pageSize: int = 50,
+    pageToken: Optional[str] = None,
+    filter: Optional[str] = None,
+    orderBy: Optional[str] = None,
+    db: Session = Depends(get_db),
+):
+    limit = max(1, min(pageSize, 200))
+    query = db.query(models.CheckIn).filter(models.CheckIn.user_id == user_id).order_by(models.CheckIn.create_time.desc()).limit(limit)
+    checkins = query.all()
+    return schemas.CheckInListResponse(checkIns=[to_checkin_response(c) for c in checkins], nextPageToken=None)
+
+
+@router.post('', response_model=schemas.CheckInResponse, status_code=201)
+def create_checkin(user_id: str, payload: schemas.CheckInCreate, db: Session = Depends(get_db)):
+    ci_in = payload.checkIn
+    checkin = models.CheckIn(
+        user_id=user_id,
+        device_id=ci_in.device_id,
+        type=ci_in.type,
+        message=ci_in.message,
+        lat=ci_in.location.lat if ci_in.location else None,
+        lng=ci_in.location.lng if ci_in.location else None,
+        accuracy_meters=ci_in.location.accuracy_meters if ci_in.location else None,
+    )
+    db.add(checkin)
+    db.commit()
+    db.refresh(checkin)
+    return to_checkin_response(checkin)

--- a/trailguard_api/schemas.py
+++ b/trailguard_api/schemas.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+
+class Location(BaseModel):
+    lat: float
+    lng: float
+    accuracy_meters: Optional[float] = Field(None, alias='accuracyMeters')
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+class CheckInPayload(BaseModel):
+    type: str
+    message: Optional[str] = None
+    device_id: Optional[str] = Field(None, alias='deviceId')
+    location: Optional[Location] = None
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+class CheckInCreate(BaseModel):
+    checkIn: CheckInPayload
+
+
+class CheckInResponse(CheckInPayload):
+    name: str
+    create_time: datetime = Field(..., alias='createTime')
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+class CheckInListResponse(BaseModel):
+    checkIns: List[CheckInResponse]
+    nextPageToken: Optional[str] = None
+
+    class Config:
+        allow_population_by_field_name = True


### PR DESCRIPTION
## Summary
- scaffold FastAPI app loading openapi.yaml
- define SQLAlchemy models matching migrations and Postgres connection
- implement check-ins endpoints and basic unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b85ec97038832eba1207c09e34b354